### PR TITLE
Add dopplershift as maintainer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,3 +46,4 @@ extra:
   recipe-maintainers:
     - sigmavirus24
     - croth1
+    - dopplershift


### PR DESCRIPTION
flake8 is a dependency of some packages I use, so I'm happy to help keep this running.