### PR TITLE
ENH: Update to flake8 3.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {%set name = "flake8" %}
-{%set version = "3.2.1" %}
+{%set version = "3.3.0" %}
 {%set hash_type = "sha256" %}
-{%set hash_val = "c7c460b5aff3a2063c798a77af18ec70af3941d35a22e2e76965e3c0e0b36055" %}
+{%set hash_val = "b907a26dcf5580753d8f80f1be0ec1d5c45b719f7bac441120793d1a70b03f12" %}
 
 package:
   name: {{ name }}
@@ -25,9 +25,9 @@ requirements:
   run:
     - configparser  # [py2k]
     - enum34  # [py2k or py33]
-    - mccabe >=0.5.0,<0.6.0
-    - pycodestyle >=2.0.0,<2.3.0
-    - pyflakes >=0.8.1,!=1.2.0,!=1.2.1,!=1.2.2,<1.4.0
+    - mccabe >=0.6.0,<0.7.0
+    - pycodestyle >=2.0.0,<2.4.0
+    - pyflakes >=1.5.0,<1.6.0
     - python
     - setuptools
 
@@ -59,3 +59,4 @@ extra:
     - croth1
     - dopplershift
     - goanpeca
+    - aydinhan


### PR DESCRIPTION
This version adds support for Python 3.6. For more details:
http://flake8.pycqa.org/en/latest/release-notes/3.3.0.html