### PR TITLE
[WIP] Loosen constraint on pycodestyle version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   {{ hash_type }}: {{ hash_val }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - configparser  # [py2k]
     - enum34  # [py2k or py33]
     - mccabe >=0.6.0,<0.7.0
-    - pycodestyle >=2.0.0,<2.4.0
+    - pycodestyle >=2.0.0
     - pyflakes >=1.5.0,<1.7.0
     - python
     - setuptools >=30.0.0


### PR DESCRIPTION
PyCodeStyle 2.4.0 has been released, fixing multiple issues (including issues on the flake8 bug tracker: [#394](https://gitlab.com/pycqa/flake8/issues/394)). It does not seem like there is any reason that flake8 should not work with `pycodestyle=2.4.0`.